### PR TITLE
fix: Scroll To Top on Route Change

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ import PaymentSuccessNFT from "./pages/PaymentSuccessNFT";
 import { useAuthState } from "@/hooks/useAuth";
 import { useEffect } from "react";
 import { registerUserForNotifications } from "@/socket";
+import ScrollToTop from "./components/ScrollToTop";
 
 const queryClient = new QueryClient();
 
@@ -48,6 +49,7 @@ const App = () => {
         <Toaster />
         <Sonner />
         <BrowserRouter>
+        <ScrollToTop/>
           <div className="min-h-screen flex flex-col">
             <Routes>
               <Route path="/login" element={<LoginPage />} />

--- a/client/src/components/ScrollToTop.tsx
+++ b/client/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
## 📄 Description

Resolved the issue where pages retained their scroll position after navigation.  
Added a `ScrollToTop` component that resets the scroll to the top of the window on every route change. This improves the overall user experience, especially for pages with long vertical content.

## 🧩 Related Issue

Closes #37 

## 📸 Evidence

- [x] Manual testing steps:
  - Navigated between different pages.
  - Verified that each new page starts from the top regardless of previous scroll position.

## ✅ TODOs

- [x] Code review
- [x] Final test cases *(manual check)*

## 🔍 Checklist before merging

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
